### PR TITLE
#4487. Removed timeout because the timeout clock starts ticking when …

### DIFF
--- a/lib/internal/checkUrl.js
+++ b/lib/internal/checkUrl.js
@@ -62,8 +62,7 @@ function checkUrl(link, baseUrl, cache, options, retry)
 		jar: true,
 		gzip: true,
 		followAllRedirects: true,
-		rejectUnauthorized: false,
-		timeout: 60000
+		rejectUnauthorized: false
 	})
 	.then( function(response)
 	{


### PR DESCRIPTION
…the URL is added to the queue, rather than when it is checked, trigging false positives.